### PR TITLE
Miita service notify

### DIFF
--- a/app/src/main/java/com/webiot_c/cprss_notifi_recv/app/BroadcastReceeiveManager.java
+++ b/app/src/main/java/com/webiot_c/cprss_notifi_recv/app/BroadcastReceeiveManager.java
@@ -12,7 +12,7 @@ public class BroadcastReceeiveManager extends BroadcastReceiver {
 
     @Override
     public void onReceive(Context context, Intent intent) {
-        Log.e("Recv", intent.getAction());
+        Log.d("Recv", intent.getAction());
         if(isBootCompleted(context, intent) || isApplicationUpdated(context, intent)){
             Intent service_intent = new Intent(context, CPRSS_BackgroundAccessService.class);
 

--- a/app/src/main/java/com/webiot_c/cprss_notifi_recv/app/service/CPRSS_BackgroundAccessService.java
+++ b/app/src/main/java/com/webiot_c/cprss_notifi_recv/app/service/CPRSS_BackgroundAccessService.java
@@ -108,9 +108,7 @@ public class CPRSS_BackgroundAccessService extends Service implements CPRSS_WebS
 
         try {
             wsclient = new CPRSS_WebSocketClient(new URI(WS_SERVER_ADDRESS), CPRSS_BackgroundAccessService.this, this );
-            Log.e("WSC", ( wsclient == null ? null : wsclient.toString()));
         } catch(Exception e){
-            Log.e("WSC", "Error occured in creating instance", e);
         }
         wsclient.connect();
         PreferencesUtility.initialize(this);
@@ -193,7 +191,7 @@ public class CPRSS_BackgroundAccessService extends Service implements CPRSS_WebS
                     getString(R.string.notify_reconnected),
                     getString(R.string.notify_reconnected));
         }
-        Log.e("WebSokcet Ret.", "Accessed to server!");
+        Log.i("WebSokcet Ret.", "Accessed to server!");
         CPRSS_BackgroundAccessService.updateStatus(CPRSS_BackgroundAccessService.this,
                 CPRSS_BackgroundAccessService.SERVER_CONNECTION_TEMP_ERROR, false);
 
@@ -260,13 +258,12 @@ public class CPRSS_BackgroundAccessService extends Service implements CPRSS_WebS
      */
     @Override
     public void onAEDUseStarted(AEDInformation aedInfo) {
-
-        Log.e("IgnoreAED", ignoredAEDID.toString());
+        Log.i("AED Event", "New AED information reserved.");
+        Log.d("IgnoreAED", ignoredAEDID.toString());
 
         if(dbhelper.isAlreadyRegistred(aedInfo.getAed_id())) return;
         if(ignoredAEDID.containsKey(aedInfo.getAed_id())) return;
 
-        Log.e("Current", (locationGetter.getCurrentLocation() == null ? "null" : locationGetter.getCurrentLocation().toString()));
         // 距離で識別する
         if(locationGetter.getCurrentLocation() != null) {
             float req_distance = PreferencesUtility.getCastedFloatValue("maximum_notification_range");
@@ -315,7 +312,7 @@ public class CPRSS_BackgroundAccessService extends Service implements CPRSS_WebS
     @Override
     public void onAEDLocationUpdated(AEDInformation aedInfo){
 
-        Log.e("AEDLocationUpdateLis", aedInfo.toString());
+        Log.i("AEDLocationUpdateLis", aedInfo.toString());
         dbhelper.updateData(aedInfo);
 
         Intent intent = new Intent();
@@ -362,7 +359,7 @@ public class CPRSS_BackgroundAccessService extends Service implements CPRSS_WebS
      */
     @Override
     public void onOtherMessage(String message) {
-        Log.e("CPRSS", "Unparsed Message: " + message);
+        Log.d("CPRSS", "Unparsed Message: " + message);
 
     }
 
@@ -373,7 +370,7 @@ public class CPRSS_BackgroundAccessService extends Service implements CPRSS_WebS
     @Override
     public void onError(Exception e) {
 
-        Log.e("CPRSS", "Error occured in WS_SERVER_ADDRESS", e);
+        Log.w("CPRSS", "Error occured in WS_SERVER_ADDRESS", e);
     }
 
 
@@ -412,13 +409,11 @@ public class CPRSS_BackgroundAccessService extends Service implements CPRSS_WebS
     public static void deleteExpiredIgnoreAEDID(){
         Set<String> keys = ignoredAEDID.keySet();
 
-        Log.e("IgnoredAED", ignoredAEDID.toString());
-
         for(String key : keys){
             Date registredTime = ignoredAEDID.get(key);
             long dayDiff_minute = DateCompareUtility.Diff(new Date(), registredTime) / 1000 / 60;
 
-            if(dayDiff_minute > 10){
+            if(dayDiff_minute > 10) {
                 deleteIgnoreAEDID(key);
             }
         }
@@ -432,7 +427,7 @@ public class CPRSS_BackgroundAccessService extends Service implements CPRSS_WebS
             service_status &= ~code;
         }
 
-        Log.w("StatusCode", "Status changed: " + service_status);
+        Log.i("StatusCode", "Status changed: " + service_status);
 
         String statusMessage = "";
         if((service_status & SERVER_CONNECTION_FAILED) != 0){

--- a/app/src/main/java/com/webiot_c/cprss_notifi_recv/connect/CPRSS_WebSocketClient.java
+++ b/app/src/main/java/com/webiot_c/cprss_notifi_recv/connect/CPRSS_WebSocketClient.java
@@ -29,7 +29,6 @@ public class CPRSS_WebSocketClient extends WebSocketClient {
         super(uri);
         this.listener = listener;
         dbhelper = AEDInformationDatabaseHelper.getInstance(context);
-        Log.e("CPRSS_WSC", "New instance!");
     }
 
     @Override
@@ -39,7 +38,7 @@ public class CPRSS_WebSocketClient extends WebSocketClient {
 
     @Override
     public void onMessage(String message) {
-        Log.e("WSC", message);
+        Log.d("WSC", message);
         String[] mes_formatted = message.split("#");
         if(mes_formatted.length != 4){
             listener.onOtherMessage(message);
@@ -65,10 +64,10 @@ public class CPRSS_WebSocketClient extends WebSocketClient {
 
             case "AED-POLLING":
                 if(!dbhelper.isAlreadyRegistred(aedInfo.getAed_id())) {
-                    Log.e("WSC", "Missed aed data! UseStarted will be called.");
+                    Log.i("WSC", "Received Missed aed data! UseStarted will be called.");
                     listener.onAEDUseStarted(aedInfo);
                 } else {
-                    Log.e("WSC", "Location update: " + aedInfo.toString());
+                    Log.i("WSC", "Location update: " + aedInfo.toString());
                     listener.onAEDLocationUpdated(aedInfo);
                 }
                 break;

--- a/app/src/main/java/com/webiot_c/cprss_notifi_recv/data_struct/AEDInformationAdapter.java
+++ b/app/src/main/java/com/webiot_c/cprss_notifi_recv/data_struct/AEDInformationAdapter.java
@@ -73,7 +73,6 @@ public class AEDInformationAdapter extends RecyclerView.Adapter<AEDInformationAd
             }
         });
 
-        Log.e("ReceivedDate", new Date().toString());
         int backcolor = context.getResources().getColor(R.color.aedinfo_very_short);;
 
         switch (aed.isReceivedDateInDuration(new Date(), 10, 30)) {

--- a/app/src/main/java/com/webiot_c/cprss_notifi_recv/utility/DateCompareUtility.java
+++ b/app/src/main/java/com/webiot_c/cprss_notifi_recv/utility/DateCompareUtility.java
@@ -18,10 +18,6 @@ public class DateCompareUtility {
 
         long dayDiff = long_aedDate - long_testDate;
 
-        Log.e("AED Duration", "[A]: " + a.toString());
-        Log.e("AED Duration", "[B]: " + b.toString());
-        Log.e("AED Duration", "Dif: " + dayDiff);
-
         return dayDiff;
 
     }

--- a/app/src/main/java/com/webiot_c/cprss_notifi_recv/utility/LocationGetter.java
+++ b/app/src/main/java/com/webiot_c/cprss_notifi_recv/utility/LocationGetter.java
@@ -1,7 +1,9 @@
 package com.webiot_c.cprss_notifi_recv.utility;
 
 import android.Manifest;
+import android.annotation.SuppressLint;
 import android.app.Activity;
+import android.app.Notification;
 import android.content.Context;
 import android.content.pm.PackageManager;
 import android.location.Criteria;
@@ -13,6 +15,7 @@ import android.support.v4.app.ActivityCompat;
 import android.util.Log;
 
 import com.webiot_c.cprss_notifi_recv.R;
+import com.webiot_c.cprss_notifi_recv.app.service.CPRSS_BackgroundAccessService;
 
 import static android.content.Context.LOCATION_SERVICE;
 
@@ -58,11 +61,7 @@ public class LocationGetter implements LocationListener {
      */
     @Override
     public void onProviderDisabled(String provider) {
-        NotificationUtility.notify(NotificationUtility.NOTIFICATION_CHANNEL_LOCATION,
-                context,
-                android.R.drawable.ic_dialog_info,
-                context.getString(R.string.notify_locservice_disable),
-                context.getString(R.string.notify_locservice_disabled_detail));
+        CPRSS_BackgroundAccessService.updateStatus(context, CPRSS_BackgroundAccessService.LOCATION_SERVICE_DISABLED, true);
     }
 
     /**
@@ -71,16 +70,13 @@ public class LocationGetter implements LocationListener {
      */
     @Override
     public void onProviderEnabled(String provider) {
-        NotificationUtility.notify(NotificationUtility.NOTIFICATION_CHANNEL_LOCATION,
-                context,
-                android.R.drawable.ic_dialog_info,
-                context.getString(R.string.notify_locservice_enabled),
-                context.getString(R.string.notify_locservice_enabled_detail));
+        CPRSS_BackgroundAccessService.updateStatus(context, CPRSS_BackgroundAccessService.LOCATION_SERVICE_DISABLED, false);
     }
 
     /**
      * 位置情報の取得を開始する。
      */
+    @SuppressLint("MissingPermission") // ← 権限はこのメソッドが呼び出される前に保障されている。。
     public void startUpdateLocation() {
         locationManager.requestLocationUpdates(bestProvider, 60000, 3, this);
     }
@@ -99,6 +95,7 @@ public class LocationGetter implements LocationListener {
         currentLocation = location;
     }
 
+    /* API29 からは呼び出されない */
     @Override
     public void onStatusChanged(String provider, int status, Bundle extras) {
 

--- a/app/src/main/java/com/webiot_c/cprss_notifi_recv/utility/LocationGetter.java
+++ b/app/src/main/java/com/webiot_c/cprss_notifi_recv/utility/LocationGetter.java
@@ -52,7 +52,7 @@ public class LocationGetter implements LocationListener {
         criteria.setVerticalAccuracy(Criteria.ACCURACY_HIGH);
 
         bestProvider = locationManager.getBestProvider(criteria, true);
-        Log.e("LocationGetter", "Best provider is " + bestProvider);
+        Log.v("LocationGetter", "Best provider is " + bestProvider);
 
     }
     /**
@@ -91,7 +91,7 @@ public class LocationGetter implements LocationListener {
     // ----- 位置情報関連 ----- //
     @Override
     public void onLocationChanged(Location location) {
-        Log.e("LocationCHanged", "Location is now changed.");
+        Log.v("LocationCHanged", "Location is now changed.");
         currentLocation = location;
     }
 

--- a/app/src/main/java/com/webiot_c/cprss_notifi_recv/utility/NotificationUtility.java
+++ b/app/src/main/java/com/webiot_c/cprss_notifi_recv/utility/NotificationUtility.java
@@ -14,6 +14,7 @@ import android.util.Log;
 import android.widget.Toast;
 
 import com.webiot_c.cprss_notifi_recv.R;
+import com.webiot_c.cprss_notifi_recv.app.service.CPRSS_BackgroundAccessService;
 
 public class NotificationUtility {
 
@@ -141,6 +142,25 @@ public class NotificationUtility {
 
         NotificationManager nm = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
         nm.notify(unique_id, builder.build());
+
+    }
+
+    /**
+     * 常時表示される通知の内容を変更する。
+     * @param context 変更を行うcontext.
+     * @param status メッセージ。
+     */
+    public static void updateServiceNotification(Context context, String status){
+
+        NotificationManager notifyman = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
+
+        NotificationCompat.Builder builder = new NotificationCompat.Builder(context,
+                NotificationUtility.NOTIFICATION_CHANNEL_BACKGROUND)
+                .setSubText(context.getString(R.string.notify_background))
+                .setSmallIcon(R.drawable.ic_server_connection)
+                .setStyle(new NotificationCompat.BigTextStyle().bigText(status));
+
+        notifyman.notify(CPRSS_BackgroundAccessService.SERVICE_FOREGROUND_NITIFICATION_ID, builder.build());
 
     }
 

--- a/app/src/main/res/values-ja-rJP/strings.xml
+++ b/app/src/main/res/values-ja-rJP/strings.xml
@@ -19,7 +19,7 @@
     <string name="notify_aed_close">AED使用が終了しました。</string>
     <string name="notify_aed_close_detail">AED使用が終了しました。ご協力ありがとうございました。</string>
     <string name="common_app_title">通知受信アプリ</string>
-    <string name="notify_background">%s - サーバー通信</string>
+    <string name="notify_background">サービスの状態</string>
     <string name="about_location">このアプリケーションは、通知を受信するかどうかを判断するために、位置情報を取得することが出来ます。\n取得した位置情報を、AEDやCPRSSサーバーなどの外部に送信することはありません。</string>
     <string name="dialog_loc_perm_context">このアプリケーションでは、周辺の情報のみを取得するために、位置情報を使用して通知するべき情報を選別します。\n次の画面に表示されるダイアログで、位置情報取得を許可してください。\n拒否された場合は、アプリケーションを終了します。</string>
     <string name="dialog_loc_perm_title">位置情報を取得するための権限が必要です。</string>
@@ -72,4 +72,9 @@
     <string name="mainui_setting">タップして設定画面へ</string>
     <string name="set_about_this_service">このサービスについて</string>
     <string name="set_about_location">位置情報について</string>
+    <string name="notify_service_fine">正常に動作しています。</string>
+    <string name="notify_service_location_enable">位置情報が有効です。</string>
+    <string name="notify_service_server_failed">サーバーに接続できません。</string>
+    <string name="notify_service_server_temporality">サーバーに再接続しています。</string>
+    <string name="notify_service_location_disable">位置情報が無効です。</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -20,7 +20,7 @@
     <string name="notify_aed_close_detail">No further lifesaving support is required. Thank you very much to your cooperation.</string>
     <string name="common_app_title">Notification Receiver</string>
     <string name="manifest_act_title_aedlocation" translatable="false">Map</string>
-    <string name="notify_background">%s - Server connection</string>
+    <string name="notify_background">Service Status</string>
     <string name="about_location">This application can know where are you to determine whether to receive notifications.\nThis application never sends the location to the outside, such as AEDs, the CPRSS Server.</string>
     <string name="dialog_loc_perm_title">"Permission to get location information is needed. "</string>
     <string name="dialog_loc_perm_context">In this application, the information to be notified is selected using the location information to obtain only the surrounding information.\nPlease allow location information acquisition in the dialog displayed on the next screen.\nIf rejected, the application will be terminated.\n</string>
@@ -72,5 +72,10 @@
     <string name="mainui_setting">Tap to move to settings screen</string>
     <string name="set_about_this_service">About this service</string>
     <string name="set_about_location">About location information</string>
+    <string name="notify_service_fine">Working normally.</string>
+    <string name="notify_service_location_enable">Location service is running.</string>
+    <string name="notify_service_server_temporality">Trying re-connect to the server...</string>
+    <string name="notify_service_server_failed">Unable to connect to server</string>
+    <string name="notify_service_location_disable">Location service is not running.</string>
 
 </resources>


### PR DESCRIPTION
Issue #13 を解決。
- 通知内容を変更した。ユーザーは(多分)ひと目でサービスの状態を確認できる。
  - 「位置情報サービスが～」という通知はなくなった。バッテリーないときウザくならない*。
- デバッグ用ログのレベルを適切に振った。

*: バッテリーセーバーがオンのとき、スリープにした時とスリープ解除した時両方通知が来てしまう。